### PR TITLE
fix: LoL RSS feed URL (Audioboom)

### DIFF
--- a/pipeline/ingest/rss_scraper.py
+++ b/pipeline/ingest/rss_scraper.py
@@ -11,8 +11,8 @@ from xml.etree import ElementTree
 import requests
 
 FEEDS = {
-    "lords_of_limited": "https://feeds.transistor.fm/lords-of-limited",
-    "limited_resources": "https://feeds.libsyn.com/51742/rss",
+    "lords_of_limited": "https://audioboom.com/channels/5064090.rss",
+    "limited_resources": "https://rss.libsyn.com/shows/44533/destinations/143254.xml",
 }
 
 SET_NAME_MAP = {


### PR DESCRIPTION
Lords of Limited moved from Transistor to Audioboom. Updates the feed URL and confirms both shows scrape correctly (493 LoL + 860 LR episodes, audio URLs present).