### PR TITLE
fix: SOS set code for Secrets of Strixhaven

### DIFF
--- a/pipeline/ingest/rss_scraper.py
+++ b/pipeline/ingest/rss_scraper.py
@@ -36,8 +36,8 @@ SET_NAME_MAP = {
     "murders": "MKM",
     "thunder junction": "OTJ",
     "caverns of ixalan": "LCI",
+    "secrets of strixhaven": "SOS",
     "strixhaven": "STX",
-    "secrets of strixhaven": "STX",
     "tarkir": "TDM",
     "aetherdrift": "AED",
     "final fantasy": "FIN",
@@ -58,10 +58,15 @@ def _extract_set_hint(title: str, description: str) -> str | None:
     for name, code in SET_NAME_MAP.items():
         if name in text:
             return code
+    _NOT_SET_CODES = {
+        "THE", "AND", "FOR", "NOT", "BUT", "RSS", "MTG", "TCG",
+        "LoL", "LOL", "LR", "SOS", "FAQ", "TBD", "TBA", "FYI",
+        "TMNT", "VOD", "API", "URL", "PDF", "ALL",
+    }
     set_code_match = re.search(r"\b([A-Z]{3,4})\b", title)
     if set_code_match:
         candidate = set_code_match.group(1)
-        if candidate not in {"THE", "AND", "FOR", "NOT", "BUT", "RSS"}:
+        if candidate not in _NOT_SET_CODES:
             return candidate
     return None
 

--- a/tests/pipeline/test_rss_scraper.py
+++ b/tests/pipeline/test_rss_scraper.py
@@ -52,9 +52,18 @@ class TestSetHintExtraction:
     def test_description_fallback(self):
         assert _extract_set_hint("Episode 400", "We cover wilds of eldraine today") == "WOE"
 
+    def test_secrets_of_strixhaven_is_sos_not_stx(self):
+        assert _extract_set_hint("Secrets of Strixhaven Crash Course", "") == "SOS"
+
+    def test_original_strixhaven_is_stx(self):
+        assert _extract_set_hint("Strixhaven Set Review", "") == "STX"
+
     def test_no_match_returns_none(self):
         result = _extract_set_hint("General Strategy Episode", "talking about drafting")
         assert result is None or isinstance(result, str)
+
+    def test_mtg_acronym_not_a_set_code(self):
+        assert _extract_set_hint("March MTG Madness", "") is None
 
 
 class TestParseDuration:


### PR DESCRIPTION
- `secrets of strixhaven` -> `SOS` (was wrongly `STX`)\n- `strixhaven` -> `STX` preserved; specific match ordered first\n- Expanded blocklist prevents MTG, TMNT, SOS-acronym etc. from being mistaken for set codes\n- 4 new tests, 21 passing