### PR TITLE
feat(#9): Scryfall client with disk caching and rate limiting

### DIFF
--- a/pipeline/cards/scryfall_client.py
+++ b/pipeline/cards/scryfall_client.py
@@ -1,0 +1,119 @@
+"""Scryfall API client with disk caching and rate limiting."""
+import json
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+_BASE = "https://api.scryfall.com"
+_SESSION = requests.Session()
+_SESSION.headers["User-Agent"] = "mtg-agent-trainer/1.0"
+
+CACHE_DIR = Path("data/card_cache")
+
+_WEEKLY = 7 * 24 * 3600
+_DAILY = 24 * 3600
+
+
+def _is_stale(path: Path, ttl: int) -> bool:
+    if not path.exists():
+        return True
+    age = datetime.now(timezone.utc).timestamp() - path.stat().st_mtime
+    return age > ttl
+
+
+def _get(url: str, **params) -> dict:
+    time.sleep(random.uniform(0.05, 0.10))
+    resp = _SESSION.get(url, params=params, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_card_names() -> list[str]:
+    """Return all ~30k oracle card names. Cached weekly."""
+    cache = CACHE_DIR / "card_names.json"
+    if not _is_stale(cache, _WEEKLY):
+        return json.loads(cache.read_text(encoding="utf-8"))
+
+    data = _get(f"{_BASE}/catalog/card-names")
+    names: list[str] = data["data"]
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(names, ensure_ascii=False), encoding="utf-8")
+    print(f"  [scryfall] card_names: {len(names)} names cached to {cache}")
+    return names
+
+
+def get_set_card_names(set_code: str) -> list[str]:
+    """Return all card names for a given set (used for Whisper prompt seeding)."""
+    cache = CACHE_DIR / f"set_{set_code.lower()}.json"
+    if not _is_stale(cache, _WEEKLY):
+        return json.loads(cache.read_text(encoding="utf-8"))
+
+    names: list[str] = []
+    url = f"{_BASE}/cards/search"
+    params: dict = {"q": f"set:{set_code}", "page": 1}
+    while True:
+        data = _get(url, **params)
+        names.extend(c["name"] for c in data.get("data", []))
+        if not data.get("has_more"):
+            break
+        params["page"] += 1
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(names, ensure_ascii=False), encoding="utf-8")
+    print(f"  [scryfall] {set_code}: {len(names)} cards cached to {cache}")
+    return names
+
+
+def get_oracle_bulk() -> Path:
+    """Download the oracle-cards bulk JSON. Cached daily. Returns local path."""
+    cache = CACHE_DIR / "oracle.json"
+    if not _is_stale(cache, _DAILY):
+        return cache
+
+    bulk_index = _get(f"{_BASE}/bulk-data")
+    download_url = None
+    for entry in bulk_index.get("data", []):
+        if entry.get("type") == "oracle_cards":
+            download_url = entry["download_uri"]
+            break
+    if not download_url:
+        raise RuntimeError("oracle_cards bulk-data entry not found")
+
+    time.sleep(random.uniform(0.05, 0.10))
+    resp = _SESSION.get(download_url, timeout=120, stream=True)
+    resp.raise_for_status()
+
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    with cache.open("wb") as f:
+        for chunk in resp.iter_content(chunk_size=65536):
+            f.write(chunk)
+
+    size_mb = cache.stat().st_size / 1_048_576
+    cards = json.loads(cache.read_text(encoding="utf-8"))
+    print(
+        f"  [scryfall] oracle bulk: {len(cards)} cards, "
+        f"{size_mb:.1f} MB, saved to {cache}"
+    )
+    return cache
+
+
+def get_card(name: str) -> dict | None:
+    """Fuzzy-search a single card by name. Caches individual lookups."""
+    slug = name.lower().replace(" ", "_").replace("/", "_")[:80]
+    cache = CACHE_DIR / "cards" / f"{slug}.json"
+    if cache.exists():
+        return json.loads(cache.read_text(encoding="utf-8"))
+
+    try:
+        data = _get(f"{_BASE}/cards/named", fuzzy=name)
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            return None
+        raise
+
+    (CACHE_DIR / "cards").mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    return data

--- a/tests/pipeline/test_scryfall_client.py
+++ b/tests/pipeline/test_scryfall_client.py
@@ -1,0 +1,192 @@
+"""Tests for pipeline/cards/scryfall_client.py"""
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses as resp_lib
+
+import pipeline.cards.scryfall_client as sc
+
+BASE = "https://api.scryfall.com"
+
+
+def _fresh_cache_dir(tmp_path):
+    cache_dir = tmp_path / "card_cache"
+    sc.CACHE_DIR = cache_dir
+    return cache_dir
+
+
+# ---------------------------------------------------------------------------
+# get_card_names
+# ---------------------------------------------------------------------------
+
+@resp_lib.activate
+def test_get_card_names_fetches_and_caches(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    resp_lib.add(resp_lib.GET, f"{BASE}/catalog/card-names",
+                 json={"data": ["Lightning Bolt", "Counterspell"]})
+
+    result = sc.get_card_names()
+    assert result == ["Lightning Bolt", "Counterspell"]
+
+    cache = sc.CACHE_DIR / "card_names.json"
+    assert cache.exists()
+    assert json.loads(cache.read_text()) == ["Lightning Bolt", "Counterspell"]
+    assert len(resp_lib.calls) == 1
+
+
+@resp_lib.activate
+def test_get_card_names_uses_cache_when_fresh(tmp_path):
+    cache_dir = _fresh_cache_dir(tmp_path)
+    cache_dir.mkdir(parents=True)
+    cache = cache_dir / "card_names.json"
+    cache.write_text(json.dumps(["Cached Card"]))
+
+    result = sc.get_card_names()
+    assert result == ["Cached Card"]
+    assert len(resp_lib.calls) == 0
+
+
+@resp_lib.activate
+def test_get_card_names_refetches_when_stale(tmp_path):
+    cache_dir = _fresh_cache_dir(tmp_path)
+    cache_dir.mkdir(parents=True)
+    cache = cache_dir / "card_names.json"
+    cache.write_text(json.dumps(["Old Card"]))
+
+    stale_time = time.time() - (8 * 24 * 3600)
+    import os
+    os.utime(cache, (stale_time, stale_time))
+
+    resp_lib.add(resp_lib.GET, f"{BASE}/catalog/card-names",
+                 json={"data": ["New Card"]})
+
+    result = sc.get_card_names()
+    assert result == ["New Card"]
+    assert len(resp_lib.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_set_card_names
+# ---------------------------------------------------------------------------
+
+@resp_lib.activate
+def test_get_set_card_names_single_page(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    resp_lib.add(resp_lib.GET, f"{BASE}/cards/search",
+                 json={"data": [{"name": "Mosswood Drifter"}, {"name": "Pawpatch Formation"}],
+                       "has_more": False})
+
+    result = sc.get_set_card_names("BLB")
+    assert "Mosswood Drifter" in result
+    assert len(resp_lib.calls) == 1
+
+
+@resp_lib.activate
+def test_get_set_card_names_paginates(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    resp_lib.add(resp_lib.GET, f"{BASE}/cards/search",
+                 json={"data": [{"name": "Card A"}], "has_more": True})
+    resp_lib.add(resp_lib.GET, f"{BASE}/cards/search",
+                 json={"data": [{"name": "Card B"}], "has_more": False})
+
+    result = sc.get_set_card_names("TST")
+    assert result == ["Card A", "Card B"]
+    assert len(resp_lib.calls) == 2
+
+
+@resp_lib.activate
+def test_get_set_card_names_uses_cache(tmp_path):
+    cache_dir = _fresh_cache_dir(tmp_path)
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "set_dsk.json").write_text(json.dumps(["Cackling Boneshard"]))
+
+    result = sc.get_set_card_names("DSK")
+    assert result == ["Cackling Boneshard"]
+    assert len(resp_lib.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_oracle_bulk
+# ---------------------------------------------------------------------------
+
+@resp_lib.activate
+def test_get_oracle_bulk_downloads_and_caches(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    bulk_data = [{"id": "1", "name": "Lightning Bolt", "type_line": "Instant"}]
+
+    resp_lib.add(resp_lib.GET, f"{BASE}/bulk-data",
+                 json={"data": [{"type": "oracle_cards",
+                                 "download_uri": "https://data.scryfall.io/oracle.json"}]})
+    resp_lib.add(resp_lib.GET, "https://data.scryfall.io/oracle.json",
+                 json=bulk_data)
+
+    path = sc.get_oracle_bulk()
+    assert path.exists()
+    assert json.loads(path.read_text()) == bulk_data
+
+
+@resp_lib.activate
+def test_get_oracle_bulk_uses_cache_when_fresh(tmp_path):
+    cache_dir = _fresh_cache_dir(tmp_path)
+    cache_dir.mkdir(parents=True)
+    cache = cache_dir / "oracle.json"
+    cache.write_text(json.dumps([{"name": "Cached"}]))
+
+    path = sc.get_oracle_bulk()
+    assert path == cache
+    assert len(resp_lib.calls) == 0
+
+
+@resp_lib.activate
+def test_get_oracle_bulk_raises_if_entry_missing(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    resp_lib.add(resp_lib.GET, f"{BASE}/bulk-data",
+                 json={"data": [{"type": "all_cards",
+                                 "download_uri": "https://data.scryfall.io/all.json"}]})
+
+    with pytest.raises(RuntimeError, match="oracle_cards"):
+        sc.get_oracle_bulk()
+
+
+# ---------------------------------------------------------------------------
+# get_card
+# ---------------------------------------------------------------------------
+
+@resp_lib.activate
+def test_get_card_fetches_and_caches(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    card_data = {"name": "Lightning Bolt", "mana_cost": "{R}"}
+    resp_lib.add(resp_lib.GET, f"{BASE}/cards/named",
+                 json=card_data)
+
+    result = sc.get_card("Lightning Bolt")
+    assert result["name"] == "Lightning Bolt"
+
+    slug_cache = sc.CACHE_DIR / "cards" / "lightning_bolt.json"
+    assert slug_cache.exists()
+
+
+@resp_lib.activate
+def test_get_card_uses_cache(tmp_path):
+    cache_dir = _fresh_cache_dir(tmp_path)
+    (cache_dir / "cards").mkdir(parents=True)
+    (cache_dir / "cards" / "lightning_bolt.json").write_text(
+        json.dumps({"name": "Lightning Bolt", "mana_cost": "{R}"})
+    )
+
+    result = sc.get_card("Lightning Bolt")
+    assert result["name"] == "Lightning Bolt"
+    assert len(resp_lib.calls) == 0
+
+
+@resp_lib.activate
+def test_get_card_returns_none_on_404(tmp_path):
+    _fresh_cache_dir(tmp_path)
+    resp_lib.add(resp_lib.GET, f"{BASE}/cards/named",
+                 json={"object": "error", "status": 404}, status=404)
+
+    result = sc.get_card("NotARealCard XYZ")
+    assert result is None


### PR DESCRIPTION
Closes #9

## Summary
- `get_card_names()` — fetches all ~30k oracle names, weekly cache
- `get_set_card_names(set_code)` — paginated set card fetch, weekly cache
- `get_oracle_bulk()` — streams oracle-cards bulk JSON, daily cache
- `get_card(name)` — fuzzy name lookup, per-card cache (no TTL)
- 50–100ms jitter between all requests

## Test plan
- [x] 12 tests all pass
- [x] Cache hit: second call reads from disk, zero HTTP calls
- [x] Stale detection: mtime-based TTL triggers re-fetch
- [x] Pagination: multi-page set search collects all cards
- [x] 404 returns None, not exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)